### PR TITLE
Update Client type with off function

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -53,6 +53,7 @@ export interface Response<T> {
 }
 export interface Client {
     on: <T>(event: string, callback: (data?: T) => void) => void;
+    off: (event: string) => void;
     invoke: <T>(name: string, ...options: any[]) => Promise<T>;
     get: <T>(name: string | string[]) => Promise<T>;
     set: <T>(name: string, value: string) => Promise<T>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendesk/sell-zaf-app-toolbox",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A package for developers that streamlines the building of Zendesk App Framework apps for Sell",
   "main": "./dist/main.js",
   "types": "./dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface Response<T> {
 
 export interface Client {
   on: <T>(event: string, callback: (data?: T) => void) => void
+  off: (event: string) => void
   invoke: <T>(name: string, ...options: any[]) => Promise<T>
   get: <T>(name: string | string[]) => Promise<T>
   set: <T>(name: string, value: string) => Promise<T>


### PR DESCRIPTION
The ZAFClient has an `off` function: https://developer.zendesk.com/apps/docs/core-api/client_api#client.offname-handler

which lets us remove an event handler from the client.