### PR TITLE
Update the AccountContext to use the correct subdomain property

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -21,7 +21,7 @@ export interface Context {
     currentUser: UserContext;
 }
 export interface AccountContext {
-    domain: string;
+    subdomain: string;
     currency: string;
     timezone: string;
     numberFormat: string;

--- a/src/hooks/useSellContactEmail.test.tsx
+++ b/src/hooks/useSellContactEmail.test.tsx
@@ -11,7 +11,7 @@ const appContext: Context = {
   location: 'person_card',
   instanceGuid: '12-323-4232-122fsfwe',
   account: {
-    domain: 'my-sell-subdomain',
+    subdomain: 'my-sell-subdomain',
     currency: 'USD',
     timezone: 'America/New_York',
     numberFormat: 'us',

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface Context {
 }
 
 export interface AccountContext {
-  domain: string
+  subdomain: string
   currency: string
   timezone: string
   numberFormat: string


### PR DESCRIPTION
It should be account.subdomain instead of account.domain

https://developer.zendesk.com/apps/docs/core-api/client_api#client.context
