### PR TITLE
fix(deps): fix 5 npm security vulnerabilities

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -12,11 +12,11 @@ return /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({
 
-/***/ "./node_modules/memoize-one/dist/memoize-one.esm.js":
+/***/ "./node_modules/memoize-one/dist/memoize-one.esm.js"
 /*!**********************************************************!*\
   !*** ./node_modules/memoize-one/dist/memoize-one.esm.js ***!
   \**********************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -68,13 +68,13 @@ function memoizeOne(resultFn, isEqual) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (memoizeOne);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./node_modules/tslib/tslib.es6.js":
+/***/ "./node_modules/tslib/tslib.es6.js"
 /*!*****************************************!*\
   !*** ./node_modules/tslib/tslib.es6.js ***!
   \*****************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -322,13 +322,13 @@ function __classPrivateFieldSet(receiver, privateMap, value) {
 }
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/components/ResponseHandler.tsx":
+/***/ "./src/components/ResponseHandler.tsx"
 /*!********************************************!*\
   !*** ./src/components/ResponseHandler.tsx ***!
   \********************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -390,13 +390,13 @@ function ResponseHandler({ children, response, responses, loadingView = null, em
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (ResponseHandler);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/formatters/useAccountDateFormat.tsx":
+/***/ "./src/formatters/useAccountDateFormat.tsx"
 /*!*************************************************!*\
   !*** ./src/formatters/useAccountDateFormat.tsx ***!
   \*************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -413,13 +413,13 @@ function useAccountDateFormat(date) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useAccountDateFormat);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/formatters/useAccountDateTimeFormat.tsx":
+/***/ "./src/formatters/useAccountDateTimeFormat.tsx"
 /*!*****************************************************!*\
   !*** ./src/formatters/useAccountDateTimeFormat.tsx ***!
   \*****************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -436,13 +436,13 @@ function useAccountDateTimeFormat(date) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useAccountDateTimeFormat);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/formatters/useCurrencyFormat.tsx":
+/***/ "./src/formatters/useCurrencyFormat.tsx"
 /*!**********************************************!*\
   !*** ./src/formatters/useCurrencyFormat.tsx ***!
   \**********************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -459,13 +459,13 @@ function useCurrencyFormat(amount, currency) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useCurrencyFormat);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/formatters/useFormattedCurrency.tsx":
+/***/ "./src/formatters/useFormattedCurrency.tsx"
 /*!*************************************************!*\
   !*** ./src/formatters/useFormattedCurrency.tsx ***!
   \*************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -484,13 +484,13 @@ const useFormattedCurrency = (amount, currency) => {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useFormattedCurrency);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/formatters/useFormattedDate.tsx":
+/***/ "./src/formatters/useFormattedDate.tsx"
 /*!*********************************************!*\
   !*** ./src/formatters/useFormattedDate.tsx ***!
   \*********************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -513,13 +513,13 @@ const useFormattedDate = (date) => {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useFormattedDate);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/formatters/useFormattedDateTime.tsx":
+/***/ "./src/formatters/useFormattedDateTime.tsx"
 /*!*************************************************!*\
   !*** ./src/formatters/useFormattedDateTime.tsx ***!
   \*************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -542,13 +542,13 @@ const useFormattedDateTime = (date) => {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useFormattedDateTime);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/formatters/useLocalDateFormat.tsx":
+/***/ "./src/formatters/useLocalDateFormat.tsx"
 /*!***********************************************!*\
   !*** ./src/formatters/useLocalDateFormat.tsx ***!
   \***********************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -565,13 +565,13 @@ function useLocalDateFormat(date) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useLocalDateFormat);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/formatters/useLocalDateTimeFormat.tsx":
+/***/ "./src/formatters/useLocalDateTimeFormat.tsx"
 /*!***************************************************!*\
   !*** ./src/formatters/useLocalDateTimeFormat.tsx ***!
   \***************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -588,13 +588,13 @@ function useLocalDateTimeFormat(date) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useLocalDateTimeFormat);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/helpers/getAppContextAsync.ts":
+/***/ "./src/helpers/getAppContextAsync.ts"
 /*!*******************************************!*\
   !*** ./src/helpers/getAppContextAsync.ts ***!
   \*******************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -609,13 +609,13 @@ const getAppContextAsync = (client) => (0,tslib__WEBPACK_IMPORTED_MODULE_0__.__a
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (getAppContextAsync);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/helpers/mergeFeedbacks.ts":
+/***/ "./src/helpers/mergeFeedbacks.ts"
 /*!***************************************!*\
   !*** ./src/helpers/mergeFeedbacks.ts ***!
   \***************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -645,13 +645,13 @@ function mergeFeedbacks(feedbacks) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (mergeFeedbacks);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/hooks/useClientGet.tsx":
+/***/ "./src/hooks/useClientGet.tsx"
 /*!************************************!*\
   !*** ./src/hooks/useClientGet.tsx ***!
   \************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -704,13 +704,13 @@ function useClientGet(path, dependencies = [], options = { skip: false }) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useClientGet);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/hooks/useClientHeight.tsx":
+/***/ "./src/hooks/useClientHeight.tsx"
 /*!***************************************!*\
   !*** ./src/hooks/useClientHeight.tsx ***!
   \***************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -735,13 +735,13 @@ const useClientHeight = (height) => {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useClientHeight);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/hooks/useClientInvoke.tsx":
+/***/ "./src/hooks/useClientInvoke.tsx"
 /*!***************************************!*\
   !*** ./src/hooks/useClientInvoke.tsx ***!
   \***************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -789,13 +789,13 @@ function useClientInvoke(name, ...options) {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useClientInvoke);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/hooks/useClientRequest.tsx":
+/***/ "./src/hooks/useClientRequest.tsx"
 /*!****************************************!*\
   !*** ./src/hooks/useClientRequest.tsx ***!
   \****************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -869,13 +869,13 @@ function useClientRequest(url, options = { skip: false }, dependencies, cacheKey
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useClientRequest);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/hooks/useClientRequestWithAuth.tsx":
+/***/ "./src/hooks/useClientRequestWithAuth.tsx"
 /*!************************************************!*\
   !*** ./src/hooks/useClientRequestWithAuth.tsx ***!
   \************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -897,13 +897,13 @@ function useClientRequestWithAuth(url, options = { skip: false }, dependencies, 
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useClientRequestWithAuth);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/hooks/useCounter.tsx":
+/***/ "./src/hooks/useCounter.tsx"
 /*!**********************************!*\
   !*** ./src/hooks/useCounter.tsx ***!
   \**********************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -923,13 +923,13 @@ const useCounter = () => {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useCounter);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/hooks/useSellContactEmail.tsx":
+/***/ "./src/hooks/useSellContactEmail.tsx"
 /*!*******************************************!*\
   !*** ./src/hooks/useSellContactEmail.tsx ***!
   \*******************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -1000,13 +1000,13 @@ function useSellContactEmail() {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (useSellContactEmail);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/providers/ZAFClientContext.tsx":
+/***/ "./src/providers/ZAFClientContext.tsx"
 /*!********************************************!*\
   !*** ./src/providers/ZAFClientContext.tsx ***!
   \********************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -1022,13 +1022,13 @@ const ZAFClientContext = react__WEBPACK_IMPORTED_MODULE_0__.createContext(ZAF_CL
 const ZAFClientContextProvider = ZAFClientContext.Provider;
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/test/flushPromises.ts":
+/***/ "./src/test/flushPromises.ts"
 /*!***********************************!*\
   !*** ./src/test/flushPromises.ts ***!
   \***********************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -1045,13 +1045,13 @@ const flushPromises = () => {
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (flushPromises);
 
 
-/***/ }),
+/***/ },
 
-/***/ "./src/types.ts":
+/***/ "./src/types.ts"
 /*!**********************!*\
   !*** ./src/types.ts ***!
   \**********************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
@@ -1084,17 +1084,17 @@ var ClientInvokeOptions;
 const version = '0.0.5';
 
 
-/***/ }),
+/***/ },
 
-/***/ "react":
+/***/ "react"
 /*!************************!*\
   !*** external "react" ***!
   \************************/
-/***/ ((module) => {
+(module) {
 
 module.exports = __WEBPACK_EXTERNAL_MODULE_react__;
 
-/***/ })
+/***/ }
 
 /******/ 	});
 /************************************************************************/
@@ -1116,6 +1116,12 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_react__;
 /******/ 		};
 /******/ 	
 /******/ 		// Execute the module function
+/******/ 		if (!(moduleId in __webpack_modules__)) {
+/******/ 			delete __webpack_module_cache__[moduleId];
+/******/ 			var e = new Error("Cannot find module '" + moduleId + "'");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
 /******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
 /******/ 	
 /******/ 		// Return the exports of the module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zendesk/sell-zaf-app-toolbox",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zendesk/sell-zaf-app-toolbox",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "memoize-one": "^5.0.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3141,9 +3141,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://zdrepo.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://zdrepo.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4346,9 +4346,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://zdrepo.jfrog.io/artifactory/api/npm/npm/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -7421,9 +7421,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://zdrepo.jfrog.io/artifactory/api/npm/npm/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://zdrepo.jfrog.io/artifactory/api/npm/npm/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -9916,9 +9916,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://zdrepo.jfrog.io/artifactory/api/npm/npm/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://zdrepo.jfrog.io/artifactory/api/npm/npm/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendesk/sell-zaf-app-toolbox",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A package for developers that streamlines the building of Zendesk App Framework apps for Sell",
   "main": "./dist/main.js",
   "types": "./dist/index.d.ts",
@@ -57,11 +57,11 @@
   },
   "overrides": {
     "lodash": "4.17.21",
-    "js-yaml": "^4.1.0",
-    "fast-uri": "3.1.2",
+    "js-yaml": "^4.3.1",
+    "fast-uri": "3.1.5",
     "ws": "^8.21.0",
-    "undici": "^7.28.0",
-    "brace-expansion": "^2.0.2",
+    "undici": "^7.29.0",
+    "brace-expansion": "^2.1.4",
     "@babel/core": "^7.29.0"
   },
   "jest": {


### PR DESCRIPTION
## 🔒 Security Fixes

| Package | Severity | Summary | Patched Version |
|---------|----------|---------|----------------|
| fast-uri | HIGH | fast-uri vulnerable to host confusion via backslash authority introducer | 3.1.5 |
| undici | HIGH | undici vulnerable to cross-user information disclosure and parse-time crash via degenerate private cache directives | 7.29.0 |
| fast-uri | HIGH | fast-uri vulnerable to host confusion via literal backslash authority delimiter | 3.1.4 |
| fast-uri | HIGH | fast-uri vulnerable to host confusion via failed IDN canonicalization | 3.1.3 |

**Vulnerabilities:** 5 → 0 (fixed 5)


## 📦 Dependency Changes

```diff
-  "version": "2.0.5",
+  "version": "2.0.6",
-    "js-yaml": "^4.1.0",
-    "fast-uri": "3.1.2",
+    "js-yaml": "^4.3.1",
+    "fast-uri": "3.1.5",
-    "undici": "^7.28.0",
-    "brace-expansion": "^2.0.2",
+    "undici": "^7.29.0",
+    "brace-expansion": "^2.1.4",
```

## 🤖 Agent Summary

All done! Here's a complete summary of everything that was found and fixed:

---

## Summary

### Vulnerabilities Found & Fixed (5 high → 0)

| Package | CVEs | Vulnerable Range | Fix | Override Change |
|---|---|---|---|---|
| **fast-uri** | GHSA-4c8g…, GHSA-v2hh…, GHSA-7p8r… (×3, CVSS 7.5) | `3.0.0–3.1.4` | `≥3.1.5` | `3.1.2` → `3.1.5` |
| **undici** | GHSA-4cwx…, GHSA-8xcm…, GHSA-m8rv…, GHSA-jr45…, GHSA-v3r7… (×5, up to CVSS 7.4) | `7.0.0–7.28.0` | `≥7.29.0` | `^7.28.0` → `^7.29.0` |
| **brace-expansion** | GHSA-mh99…, GHSA-rgw5… (×2, CVSS 7.5) | `2.0.0–2.1.3` | `≥2.1.4` | `^2.0.2` → `^2.1.4` |
| **js-yaml** | GHSA-5p4m… (×1, CVSS 7.5) | `4.0.0–4.3.0` | `≥4.3.1` | `^4.1.0` → `^4.3.1` |

### Root Causes (Dependency Chains)
- `webpack → schema-utils → ajv → fast-uri`
- `enzyme → cheerio → undici`
- `jest → @jest/core → glob → minimatch → brace-expansion` and `tslint → minimatch → brace-expansion`
- `ts-jest → @jest/transform → babel-plugin-istanbul → @istanbuljs/load-nyc-config → js-yaml` and `tslint → js-yaml`

### Approach
All four were already in the `overrides` section, but **pinned to still-vulnerable versions**. The fix was simply updating each override to the minimum patched version. No direct dependency upgrades were needed or possible, as no parent package naturally resolves the safe transitive version within its current semver range.

### Verification
- ✅ `npm install` — **0 vulnerabilities** (down from 5 high)
- ✅ `npm run build` — webpack compiled successfully
- ✅ `npm run lint` — tslint clean
- ✅ `npm test` — all tests passed
- ✅ Version bumped: `2.0.5` → `2.0.6`

---

## Changes
fix(deps): apply automated remediation for zendesk/sell-zaf-app-toolbox

---
fix(deps): patch 5 high-severity CVEs via npm overrides\n\n## Vulnerabilities fixed\n\n### fast-uri (3 CVEs) — override 3.1.2 → 3.1.5\n- GHSA-4c8g-83qw-93j6 / Dependabot #146 (CVE, CVSS 7.5)\n  fast-uri vulnerable to host confusion via failed IDN canonicalization\n  Affected: >=3.0.0 <3.1.3\n- GHSA-v2hh-gcrm-f6hx / Dependabot #147 (CVSS 7.5)\n  fast-uri vulnerable to host confusion via literal backslash authority delimiter\n  Affected: >=3.0.0 <=3.1.3\n- GHSA-7p8r-x3mc-p8w7 / Dependabot #154 (CVSS 7.5)\n  fast-uri vulnerable to host confusion via backslash authority introducer\n  Affected: >=3.0.0 <3.1.5\n  Root cause: webpack → schema-utils → ajv → fast-uri\n\n### undici (5 CVEs) — override ^7.28.0 → ^7.29.0\n- GHSA-4cwx-7wf7-3272 / Dependabot #149 (CVSS 7.4, HIGH)\n  Cross-user information disclosure and parse-time crash via degenerate private cache directives\n- GHSA-8xcm-r25x-g524 (CVSS 4.8) — downstream response desynchronization via retry interceptor\n- GHSA-m8rv-5g2x-5cg5 (CVSS 4.2) — CRLF Injection via blob-like body 'type' property\n- GHSA-jr45-8vmc-qm54 (CVSS 5.9) — cross-user info disclosure via whitespace in Cache-Control\n- GHSA-v3r7-h72x-cjcm (CVSS 4.8) — cookie attribute injection via unsanitized domain\n  Affected: >=7.0.0 <7.29.0\n  Root cause: enzyme → cheerio → undici\n\n### brace-expansion (2 CVEs) — override ^2.0.2 → ^2.1.4\n- GHSA-mh99-v99m-4gvg (CVSS 7.5) — DoS via unbounded expansion length (OOM crash)\n  Affected: >=2.0.0 <2.1.3\n- GHSA-rgw5-rvv9-x895 (CVSS 7.5) — DoS via unbounded intermediate arrays (bypass of prior fix)\n  Affected: >=2.0.0 <2.1.4\n  Root causes: jest/@jest/core/reporters → glob → minimatch → brace-expansion\n               tslint → minimatch → brace-expansion\n\n### js-yaml (1 CVE) — override ^4.1.0 → ^4.3.1\n- GHSA-5p4m-2wfm-xmqj (CVSS 7.5) — Quadratic CPU consumption in !!omap resolution (DoS)\n  Affected: >=4.0.0 <4.3.1\n  Root causes: ts-jest → @jest/transform → babel-plugin-istanbul → @istanbuljs/load-nyc-config → js-yaml\n               tslint → js-yaml\n\n## Approach\nAll vulnerable packages are transitive (not direct dependencies).\nOverrides were already present for all four but were pinned to still-vulnerable\nversions. Updated each override to the minimum patched version.\nNo direct dependency upgrades were possible since no parent package naturally\npulls in the safe transitive versions within its current semver range.\n\n## Verification\n- up to date, audited 740 packages in 1s
157 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities: 0 vulnerabilities (was 5 high)\n-
> @zendesk/sell-zaf-app-toolbox@2.0.6 build
> npm run clean && NODE_ENV=production webpack

> @zendesk/sell-zaf-app-toolbox@2.0.6 clean
> rm -rf ./dist

assets by path hooks/*.ts 1.49 KiB 12 assets
assets by path formatters/*.ts 1.23 KiB 11 assets
assets by path helpers/*.ts 310 bytes
  asset helpers/getAppContextAsync.d.ts 158 bytes [emitted]
  + 2 assets
assets by path *.ts 3.69 KiB
  asset types.d.ts 2.4 KiB [emitted]
  asset index.d.ts 1.29 KiB [emitted]
assets by path components/*.ts 1020 bytes
  asset components/ResponseHandler.d.ts 1000 bytes [emitted]
  asset components/ResponseHandler.test.d.ts 11 bytes [emitted]
asset main.js 60.3 KiB [emitted] (name: main)
asset providers/ZAFClientContext.d.ts 224 bytes [emitted]
asset test/flushPromises.d.ts 90 bytes [emitted]
webpack compiled successfully in 958 ms: ✅ webpack compiled successfully\n-
> @zendesk/sell-zaf-app-toolbox@2.0.6 lint
> tslint --project tsconfig.json --fix: ✅ tslint passed\n-
> @zendesk/sell-zaf-app-toolbox@2.0.6 test
> jest: ✅ all tests passed

---